### PR TITLE
Fix ambiguous selector in Xcode 13

### DIFF
--- a/PixelTest/PixelTestCase.swift
+++ b/PixelTest/PixelTestCase.swift
@@ -45,7 +45,7 @@ open class PixelTestCase: XCTestCase {
     // MARK: Internal
     
     convenience init(layoutCoordinator: LayoutCoordinatorType = LayoutCoordinator(), recordCoordinator: RecordCoordinatorType = RecordCoordinator(), testCoordinator: TestCoordinatorType = TestCoordinator(), fileCoordinator: FileCoordinatorType = FileCoordinator()) {
-        self.init(selector: #selector(setUp))
+        self.init(selector: #selector(PixelTestCase.setUp))
         self.layoutCoordinator = layoutCoordinator
         self.recordCoordinator = recordCoordinator
         self.testCoordinator = testCoordinator


### PR DESCRIPTION
The `setup` selector referenced in the convenience initializer of `PixelTestCase` is found to be ambiguous in Xcode 13, and so fails to compile. This PR disambiguates the selector.